### PR TITLE
rtl: sh instead of bash

### DIFF
--- a/apps/ride-the-lightning/rtl/entrypoint.sh
+++ b/apps/ride-the-lightning/rtl/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Migrate legacy default password
 sed -i 's/"multiPassHashed": "70c882380045d35807b45245bd49185991904ff47a5036dfe82103c49f9f0f31"/"multiPass": "'${APP_PASSWORD}'"/' $RTL_CONFIG_PATH/RTL-Config.json


### PR DESCRIPTION
A user got the following error for RTL after upgrading to 0.4.8:

`docker logs ride-the-lightning_web_1 
env: can't execute 'bash': No such file or directory`

Making this change appears to have fixed it for him